### PR TITLE
Fixes to Podspec

### DIFF
--- a/ios/RNSqlite2.podspec
+++ b/ios/RNSqlite2.podspec
@@ -6,19 +6,17 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNSqlite2
                    DESC
-  s.homepage     = ""
-  s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  s.homepage     = "https://github.com/craftzdog/react-native-sqlite-2"
+  s.license      = "Apache 2.0"
+  s.author       = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNSqlite2.git", :tag => "master" }
-  s.source_files  = "RNSqlite2/**/*.{h,m}"
+  s.source       = { :git => "https://github.com/craftzdog/RNSqlite2.git", :tag => "master" }
+  s.source_files = "**/*.{h,m}"
   s.requires_arc = true
-
+  s.library      = "sqlite3"
 
   s.dependency "React"
   #s.dependency "others"
 
 end
 
-  


### PR DESCRIPTION
When integrating this project into an iOS project we found some changes to the podspec were required in order for CocoaPods to properly link and compile the project:

 * The `homepage` option is required.
 * The source files were initially not being found in the 'Pods' project.
 * The linker would fail due to missing symbols from the sqlite3 library.

This PR addresses these issues, and also fixes some of the metadata which was not correct or missing.