### PR TITLE
Fix framework target

### DIFF
--- a/windows/RNSqlite2/project.json
+++ b/windows/RNSqlite2/project.json
@@ -4,7 +4,7 @@
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2"
   },
   "frameworks": {
-    "uap10.0": {}
+    "uap10.0.10586": {}
   },
   "runtimes": {
     "win10-arm": {},


### PR DESCRIPTION
Having issues building with the newest react-native-windows.
For some reason having a target framework of "uap10.0" is invalid. I instead pointed it at 10586 and my build issues were solved. I think there was some breaking change happening either within react-native's ecosystem or UWP apps since the last sdk release.