### PR TITLE
Android: handle REAL datatype correctly

### DIFF
--- a/android/src/main/java/dog/craftz/sqlite_2/RNSqlite2Module.java
+++ b/android/src/main/java/dog/craftz/sqlite_2/RNSqlite2Module.java
@@ -177,7 +177,7 @@ public class RNSqlite2Module extends ReactContextBaseJavaModule {
   private Object getValueFromCursor(Cursor cursor, int index, int columnType) {
     switch (columnType) {
       case Cursor.FIELD_TYPE_FLOAT:
-        return cursor.getFloat(index);
+        return cursor.getDouble(index);
       case Cursor.FIELD_TYPE_INTEGER:
         return cursor.getInt(index);
       case Cursor.FIELD_TYPE_BLOB:


### PR DESCRIPTION
It looks like on Android big REAL number were put on a float data type, which resulted in incorrect queries results. This PR fixes the issue for my use case. Not sure if it has any negative implications. 