### PR TITLE
Update websql dependency to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "lodash.map": "^4.6.0",
     "lodash.zipobject": "^4.1.3",
-    "websql": "^0.4.4"
+    "websql": "^1.0.0"
   }
 }


### PR DESCRIPTION
This adds compatibility with Node 10 (sqlite3 3.x which is a dependency of websql won't compile; websql 1.0.0 uses sqlite3 4.0 which compiles fine)