### PR TITLE
fix(android): Fix integer overflow for SELECT result

### DIFF
--- a/android/src/main/java/dog/craftz/sqlite_2/RNSqlite2Module.java
+++ b/android/src/main/java/dog/craftz/sqlite_2/RNSqlite2Module.java
@@ -192,7 +192,7 @@ public class RNSqlite2Module extends ReactContextBaseJavaModule {
       case Cursor.FIELD_TYPE_FLOAT:
         return cursor.getDouble(index);
       case Cursor.FIELD_TYPE_INTEGER:
-        return cursor.getInt(index);
+        return cursor.getLong(index);
       case Cursor.FIELD_TYPE_BLOB:
         // convert byte[] to binary string; it's good enough, because
         // WebSQL doesn't support blobs anyway


### PR DESCRIPTION
Summary:
    On Java/Android, int/Integer is 32bits.
    The data from SELECT result might be truncated.
    This commit use 64bits Long to retrieve SQLite result.