### PR TITLE
Fix Xcode warnings -- define logDebug function and give initial value…

### DIFF
--- a/ios/RNSqlite2.h
+++ b/ios/RNSqlite2.h
@@ -7,7 +7,11 @@
 
 #import <Foundation/Foundation.h>
 
-#define logDebug
+#ifdef shouldLog
+#define logDebug(fmt, ...) NSLog((@"%s [Line %d] " fmt), __PRETTY_FUNCTION__, __LINE__, ##__VA_ARGS__);
+#else
+#define logDebug(...)
+#endif
 
 @interface RNSqlite2 : NSObject <RCTBridgeModule>
 

--- a/ios/RNSqlite2.m
+++ b/ios/RNSqlite2.m
@@ -174,14 +174,14 @@ RCT_EXPORT_METHOD(exec:(NSString *)dbName
     }
   }
 
-  int previousRowsAffected;
+  int previousRowsAffected = 0;
   if (!queryIsReadOnly) {
     // calculate the total changes in order to diff later
     previousRowsAffected = sqlite3_total_changes(db);
   }
 
   // iterate through sql results
-  int columnCount;
+  int columnCount = 0;
   NSMutableArray *columnNames = [NSMutableArray arrayWithCapacity:0];
   NSString *columnName;
   int columnType;


### PR DESCRIPTION
Mark logDebug as conditional (wrapped with an undefined shouldLog right now) and then given vargs so that Xcode doesn't complain about unused returns or misplaced commas.

Two ints given initial values.

With this pull, as of Xcode 10.2.1, warnings go from 20+ for this project to 0.