### PR TITLE
ignore android/build folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -39,6 +39,7 @@ build/
 .gradle
 local.properties
 *.iml
+android/build
 
 # BUCK
 buck-out/


### PR DESCRIPTION
removes
<img width="272" alt="image" src="https://user-images.githubusercontent.com/13404754/87162095-c359a780-c2c5-11ea-8112-150669de450f.png">

reduces size of the repo
<img width="272" alt="image" src="https://user-images.githubusercontent.com/13404754/87162123-c9e81f00-c2c5-11ea-9062-5eec25a2dfa9.png">
