### PR TITLE
Send PRAGMA queries to SELECT handler (Android)

### DIFF
--- a/android/src/main/java/dog/craftz/sqlite_2/RNSqlite2Module.java
+++ b/android/src/main/java/dog/craftz/sqlite_2/RNSqlite2Module.java
@@ -87,7 +87,7 @@ public class RNSqlite2Module extends ReactContextBaseJavaModule {
             String sql = sqlQuery.getString(0);
             ReadableArray queryArgs = sqlQuery.getArray(1);
             try {
-              if (isSelect(sql)) {
+              if (isSelectOrPragmaQuery(sql)) {
                 results[i] = doSelectInBackgroundAndPossiblyThrow(sql, queryArgs, db);
               } else { // update/insert/delete
                 if (readOnly) {
@@ -284,8 +284,10 @@ public class RNSqlite2Module extends ReactContextBaseJavaModule {
     return data;
   }
 
-  private static boolean isSelect(String str) {
-    return startsWithCaseInsensitive(str, "select");
+
+  private static boolean isSelectOrPragmaQuery(String str) {
+    return startsWithCaseInsensitive(str, "select") ||
+            (startsWithCaseInsensitive(str, "pragma") && !str.contains("="));
   }
   private static boolean isInsert(String str) {
     return startsWithCaseInsensitive(str, "insert");


### PR DESCRIPTION
This patch addresses Issue #65. Basically we just want to treat a PRAGMA query (but not an assignment) with the same handler as the one which does SELECT, so that it can return the results of the query (and not throw the exception named in the issue).

Semi-related, and I didn't include this change in this pull request, but in order to enable foreign key support I had to add a call to `database.setForeignKeyConstraintsEnabled(true);` in the Module just after `database = SQLiteDatabase.openOrCreateDatabase(file, null);`. Apparently Android won't respect `PRAGMA foreign_keys = ON` if you do it at a later time. I wasn't sure how best to address this, whether to add a parameter to `openDatabase` in `src/index.js` (which would defy the websql API it's going for) or to add a parameter to both the `RNSqlite2Package` and `RNSqlite2Module` constructors (which looks ugly but at least doesn't mess with the API). I was wondering if you had any other ideas or if you want me to do it one of these ways I can submit another PR.

Cheers