### PR TITLE
Beeks/enable fk by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ try {
 
 Note that it requires Android 9 (API level 28).
 
+### Foreign key support on Android
+
+As part of database initialization, this library will enable foreign key support automatically on Android devices, due to the fact that Android will not respect a PRAGMA statement to enable or disable them after it has been opened. Thus, any tables that define foreign key constraints will have them enforced whether or not foreign key support is explicitly enabled/disabled by PRAGMA statements sent via SQL.
+
 ## Changelog
 
 See [CHANGELOG.md](./CHANGELOG.md)

--- a/android/src/main/java/dog/craftz/sqlite_2/RNSqlite2Module.java
+++ b/android/src/main/java/dog/craftz/sqlite_2/RNSqlite2Module.java
@@ -221,6 +221,7 @@ public class RNSqlite2Module extends ReactContextBaseJavaModule {
         File file = new File(this.context.getFilesDir(), name);
         database = SQLiteDatabase.openOrCreateDatabase(file, null);
       }
+      database.setForeignKeyConstraintsEnabled(true);
       DATABASES.put(name, database);
     }
     return database;


### PR DESCRIPTION
As discussed in https://github.com/craftzdog/react-native-sqlite-2/pull/91, here's the PR to enable foreign key constraints in Android