### PR TITLE
Enforce foreign key constraints on iOS as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ PouchDB.plugin(SQLiteAdapter);
 var db = new PouchDB("mydb", { adapter: "react-native-sqlite" });
 ```
 
-### Foreign key support on Android
+### Foreign key support
 
-As part of database initialization, this library will enable foreign key support automatically on Android devices, due to the fact that Android will not respect a PRAGMA statement to enable or disable them after it has been opened. Thus, any tables that define foreign key constraints will have them enforced whether or not foreign key support is explicitly enabled/disabled by PRAGMA statements sent via SQL.
+As part of database initialization, this library will enable foreign key support automatically on both iOS & Android. Thus, any tables that define foreign key constraints will have them enforced whether or not foreign key support is explicitly enabled/disabled by PRAGMA statements sent via SQL.
 
 ## Changelog
 

--- a/ios/RNSqlite2.m
+++ b/ios/RNSqlite2.m
@@ -79,6 +79,7 @@ RCT_EXPORT_MODULE()
       logDebug(@"cannot open database: %@", dbName); // shouldn't happen
     };
     cachedDB = [NSValue valueWithPointer:db];
+    sqlite3_exec(db, "PRAGMA foreign_keys = ON;", NULL, NULL, NULL);
     @synchronized(cachedDatabases) {
       [cachedDatabases setObject: cachedDB forKey: dbName];
     }


### PR DESCRIPTION
This addresses https://github.com/craftzdog/react-native-sqlite-2/pull/91#issuecomment-805497837 and thus streamlines default foreign key enforcing to be handled the same way on both platforms.