### PR TITLE
remove jcenter - update sqlite to safe newer version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,5 +37,5 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     api 'androidx.sqlite:sqlite:2.0.1'
-    implementation 'io.requery:sqlite-android:3.29.0'
+    implementation 'com.github.requery:sqlite-android:3.30.1'
 }


### PR DESCRIPTION
JCenter central artifact repository is going to shut down this year and this package will not be available anymore. It's available on Jitpack from version 3.30.1. Also react native removed center jcenter repo in 0.65.0. 

https://jitpack.io/#requery/sqlite-android

https://blog.gradle.org/jcenter-shutdown