### PR TITLE
fix: fetch Gradle only when necessary

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,13 +1,13 @@
-
 buildscript {
-    repositories {
-        mavenCentral()
-        google()
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+    if (project == rootProject) {
+        repositories {
+            mavenCentral()
+            google()
+            jcenter()
+        }
+        dependencies {
+            classpath 'com.android.tools.build:gradle:3.2.1'
+        }
     }
 }
 


### PR DESCRIPTION
The Android Gradle plugin is only required when opening the android folder stand-alone. This avoids unnecessary downloads and potential conflicts when the library is included as a module dependency in an application project.