### PR TITLE
fix(android): Patch sqlite lib for 16 KB page size support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,5 +61,5 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
   api 'androidx.sqlite:sqlite:2.1.0'
-  implementation 'com.github.requery:sqlite-android:3.36.0'
+  implementation 'com.github.requery:sqlite-android:3.49.0'
 }


### PR DESCRIPTION
### Description

This PR updates react-native-sqlite-2 to support [Android's 16 KB page sizes](https://developer.android.com/guide/practices/page-sizes).

Without this, we can't upload to the Play Store because the old binaries are still 4 KB aligned. I’ve been using `patch-package` to fix this locally, but that's messy, this PR applies the fix directly to the library. I've tested it and it works great.
